### PR TITLE
Mobile display disabled

### DIFF
--- a/index.css
+++ b/index.css
@@ -24,7 +24,7 @@ body {
     /* width: 100%; */
     flex: auto;
     padding: 30px;
-    border: 4px solid black;
+    border: 4px solid rgb(0, 0, 0);
     box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.4);
 }
 
@@ -43,7 +43,7 @@ body {
 
 #body_header_block h1 {
     margin: 0px;
-    font-size: 6vw;
+    font-size: clamp(24px, 4vw + 48px, 120px);
     text-shadow: rgba(0, 0, 0, 0.2) 6px 6px;
     text-align: left;
     /* make the first name/surname wrap around */
@@ -60,11 +60,11 @@ body {
 
 #body_header_block h2 {
     margin: 0px;
-    font-size: 2vw;
+    font-size: clamp(16px, 2vw + 24px, 55px);
     text-shadow: rgba(0, 0, 0, 0.2) 6px 6px;
-    text-align: right;
-    /* background-color: rgba(255, 255, 255, 0.5); */
-    /* box-shadow: 8px 8px 5px rgba(0, 0, 0, 0.55); */
+    text-align: center;
+    background-color: rgba(255, 255, 255, 0.995);
+    box-shadow: 8px 8px 5px rgba(0, 0, 0, 0.55);
     display:inline;
     padding: 5px 10px;
     border-radius: 5px;
@@ -72,20 +72,22 @@ body {
 
 /* applies to block */
 .content_block {
-    margin: 2% 2%;
+    margin: 2.5% 5%;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     height: 500px;
-    background: url('./assets/default_content_placeholder_background.webp'); /* Fallback if block background image can't load */
+    /* Fallback if block background image can't load */
+    background: url('./assets/default_content_placeholder_background.webp') no-repeat center;
     background-size: cover;
     border-radius: 15px;
 }
 
+/* There are style similarities between h1/p  and content block/header block variations - could combine these styles?*/
 /* Content block title/header text */
 .content_block h1 {
     margin: 0px; /* Remove default h1 margin */
-    font-size: 4vw;
+    font-size: clamp(24px, 4vw + 36px, 90px);
     text-align: left;
     word-wrap: normal;
     /* add background behind text */
@@ -99,7 +101,7 @@ body {
 /* Content block descriptive text  */
 .content_block p {
     margin: 0px;
-    font-size: 2vw;
+    font-size: clamp(16px, 2vw + 24px, 60px);
     text-align: right;
     word-wrap: normal;
     align-self: flex-end;
@@ -116,3 +118,13 @@ body {
     height: 20px;
     visibility: hidden;
 }
+
+
+/* Mobile display for content block */
+@media (max-width: 768px) {
+    .content_block {
+      background-size: cover;
+      background-position-x: 43%;
+      /* background-size: 400%; */
+      /* background-position: center; */
+    }

--- a/index.css
+++ b/index.css
@@ -7,11 +7,16 @@ body {
     background-size: cover;
 }
 
-#construction_banner {
+.construction_element {
     background-color: rgb(214, 214, 162);
     min-height: 20px;
     margin: 20px 4px 40px;
     text-align: center;
+    padding: 20px;
+}
+
+.hidden {
+    display: none;
 }
 
 #flex_container {

--- a/index.css
+++ b/index.css
@@ -120,8 +120,13 @@ body {
 }
 
 
-/* Mobile display for content block */
+/* Mobile display changes*/
 @media (max-width: 768px) {
+    body {
+        /* background-repeat:repeat-y; */
+        background-size: 150vh;
+        background-position:top;
+    }
     .content_block {
       background-size: cover;
       background-position-x: 43%;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
 
   <!-- Main body -->
   <div id="root">
+
+    <div class="construction_element hidden" id="mobile_banner">
+      <p>Limited width (i.e. mobile) functionality for this site has been temporarily disabled, please switch your browser to show desktop view.</p>
+    </div>
     
     <div id="flex_container">
       <!-- Main page header goes in here -->
@@ -36,11 +40,16 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
         loadDiv('navbar_container', 'header.html');
+        // if (window.innerWidth < 768) {} else {
         addContentBlock('assets/block_background_1_coding.png', 'Software Developer', 'Experienced with multiple development languages');
         addContentBlock('assets/block_background_2_data.png', 'Data Analyst', 'Spreadsheet and database capabilities');
         addContentBlock('assets/block_background_3_gamedev.png', 'Game Developer', 'Multiple completed game projects');
         addContentBlock('assets/block_background_4_figma.png', 'Designer', 'Artistic and design skills');
         addContentBlock('assets/block_background_5_writing.png', 'Writer', 'Published content writer');
+        // }
+    });
+    window.addEventListener('resize', () => {
+      toggleMobileWarning();      
     });
   </script>
 </body>

--- a/index.js
+++ b/index.js
@@ -62,3 +62,19 @@ function addContentBlock(arg_background_url, arg_title, arg_text) {
   new_div.appendChild(new_header)
   new_div.appendChild(new_subtext)
 }
+
+// when user tries to view site on mobile a warning that the site is designed for desktop is shown
+function toggleMobileWarning() {
+  let flex_root = document.getElementById("flex_container")
+  let mobile_banner = document.getElementById("mobile_banner")
+  if ((flex_root != null) && (mobile_banner != null)) {
+    let is_small = (window.innerWidth < 768)
+    if (is_small === true) {
+      flex_root.style.display = "none";
+      mobile_banner.style.display = "block";
+    } else {
+      flex_root.style.display = "block";
+      mobile_banner.style.display = "none";
+    }
+  }
+}


### PR DESCRIPTION
Mobile display is currently very ugly due to the size of content blocks background images as the resolutions aren't mobile friendly. As a temporary fix have disabled content blocks when site width gets too thin and added a warning to the user to use the desktop site

**Possible future fixes**
* adding horizontal space on the edges of the image and removing on mobile display
* assign ids to content blocks/change their background urls on demand
* add fallback mobile images for content block generation method